### PR TITLE
[FIX] build.gradle 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+jar {
+	enabled = false
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }


### PR DESCRIPTION
빌드 시 jar 파일 2개 만들어지는 것을 방지